### PR TITLE
Wait backoff

### DIFF
--- a/bake
+++ b/bake
@@ -60,7 +60,7 @@ EOF
 function pipe_wait() {
     until pipe_ssh_exit
     do
-        true
+        sleep 1
     done
 }
 


### PR DESCRIPTION
This used to be printing lots of connection reset statements. This just makes it less frequent and doesn't hit the emulator constantly.